### PR TITLE
[12] bugfix

### DIFF
--- a/src/main/java/com/kuroneko/config/CONSTANTS.java
+++ b/src/main/java/com/kuroneko/config/CONSTANTS.java
@@ -17,6 +17,7 @@ public class CONSTANTS {
     public static final int LOG_ARGUMENT_CHUNK_SIZE = 255;
 
     public static final List<GameQueueType> RELEVANT_QUEUES = List.of(GameQueueType.RANKED_FLEX_SR, GameQueueType.RANKED_SOLO_5X5, GameQueueType.TEAM_BUILDER_RANKED_SOLO);
+    public static final List<GameQueueType> RELEVANT_QUEUES_MATCH_HISTORY = List.of(GameQueueType.RANKED_FLEX_SR, GameQueueType.TEAM_BUILDER_RANKED_SOLO);
 
     public static final int API_FETCH_MATCHES_CRON = 5;
     public static final int API_FETCH_MATCHES_NEW_SUMMONER = 15;

--- a/src/main/java/com/kuroneko/database/entity/MatchEntity.java
+++ b/src/main/java/com/kuroneko/database/entity/MatchEntity.java
@@ -17,7 +17,7 @@ import java.util.Set;
 @Setter
 public class MatchEntity {
     @Id
-    private Long matchId;
+    private String matchId;
 
     private int gameDuration;
     private long gameStart;

--- a/src/main/java/com/kuroneko/database/mapper/MatchMapper.java
+++ b/src/main/java/com/kuroneko/database/mapper/MatchMapper.java
@@ -4,9 +4,9 @@ import com.kuroneko.database.entity.MatchEntity;
 import no.stelar7.api.r4j.pojo.lol.match.v5.LOLMatch;
 
 public class MatchMapper {
-    public static MatchEntity map(LOLMatch match) {
+    public static MatchEntity map(LOLMatch match, String matchId) {
         MatchEntity matchEntity = new MatchEntity();
-        matchEntity.setMatchId(match.getGameId());
+        matchEntity.setMatchId(matchId);
         matchEntity.setGameName(match.getGameName());
         matchEntity.setGameType(match.getGameType());
         matchEntity.setGameQueueType(match.getQueue());

--- a/src/main/java/com/kuroneko/database/repository/MatchRepository.java
+++ b/src/main/java/com/kuroneko/database/repository/MatchRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MatchRepository extends JpaRepository<MatchEntity, Long>{
+public interface MatchRepository extends JpaRepository<MatchEntity, String>{
 }

--- a/src/main/java/com/kuroneko/database/repository/MatchSummonerRepository.java
+++ b/src/main/java/com/kuroneko/database/repository/MatchSummonerRepository.java
@@ -25,7 +25,7 @@ public interface MatchSummonerRepository extends JpaRepository<MatchSummonerEnti
 
     @Query("SELECT ms FROM MatchSummonerEntity ms WHERE ms.match.matchId IN :matchIds AND ms.summoner.puuid = :puuid")
     List<MatchSummonerEntity> findByMatchIdsAndSummonerPuuid(
-            @Param("matchIds") Collection<Long> matchIds,
+            @Param("matchIds") Collection<String> matchIds,
             @Param("puuid") String puuid
     );
 }

--- a/src/main/java/com/kuroneko/database/repository/MatchSummonerRepository.java
+++ b/src/main/java/com/kuroneko/database/repository/MatchSummonerRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 
 @Repository
@@ -21,4 +22,10 @@ public interface MatchSummonerRepository extends JpaRepository<MatchSummonerEnti
     List<MatchSummonerEntity> findLastMatchesBySummonerId(@Param("puuid") String puuid, @Param("matches") int matches);
 
     boolean existsBySummonerPuuid(String puuid);
+
+    @Query("SELECT ms FROM MatchSummonerEntity ms WHERE ms.match.matchId IN :matchIds AND ms.summoner.puuid = :puuid")
+    List<MatchSummonerEntity> findByMatchIdsAndSummonerPuuid(
+            @Param("matchIds") Collection<Long> matchIds,
+            @Param("puuid") String puuid
+    );
 }

--- a/src/main/java/com/kuroneko/service/MatchHistoryService.java
+++ b/src/main/java/com/kuroneko/service/MatchHistoryService.java
@@ -38,6 +38,7 @@ public class MatchHistoryService {
         List<MatchSummonerEntity> newMatchSummoners = new ArrayList<>();
 
         boolean newMatchPlayed = false;
+        boolean newMatchSummoner = false;
         boolean isNewSummoner = !matchSummonerRepository.existsBySummonerPuuid(summonerEntity.getPuuid());
 
         int fetchCount = isNewSummoner ? API_FETCH_MATCHES_NEW_SUMMONER : API_FETCH_MATCHES_CRON;
@@ -75,17 +76,34 @@ public class MatchHistoryService {
                 .map(LOLMatch::getGameId)
                 .toList();
 
-        Set<Long> existingMatchIds = new HashSet<>(matchRepository.findAllById(gameIds)
+        Map<Long, MatchEntity> existingMatches = new HashMap<>(matchRepository.findAllById(gameIds)
                 .stream()
-                .map(MatchEntity::getMatchId)
-                .toList());
+                .collect(Collectors.toMap(
+                        MatchEntity::getMatchId,
+                        matchEntity -> matchEntity
+                )));
+
+        Map<Long, MatchSummonerEntity> existingMatchIdsForSummoner =
+                matchSummonerRepository.findByMatchIdsAndSummonerPuuid(gameIds, summonerEntity.getPuuid())
+                        .stream()
+                        .collect(Collectors.toMap(
+                                matchSummonerEntity -> matchSummonerEntity.getMatch().getMatchId(),
+                                matchSummonerEntity -> matchSummonerEntity
+                        ));
 
         for (LOLMatch match : lolMatches) {
-            if (!existingMatchIds.contains(match.getGameId())) {
+            if (!existingMatches.containsKey(match.getGameId())) {
                 newMatchPlayed = true;
                 MatchEntity newMatchEntity = MatchMapper.map(match);
 
                 newMatches.add(newMatchEntity);
+                newMatchSummoners.add(MatchSummonerMapper.map(
+                        newMatchEntity, summonerEntity, participantByMatchId.get(match.getGameId())
+                ));
+            } else if (!existingMatchIdsForSummoner.containsKey(match.getGameId())) {
+                newMatchSummoner = true;
+
+                MatchEntity newMatchEntity = existingMatches.get(match.getGameId());
                 newMatchSummoners.add(MatchSummonerMapper.map(
                         newMatchEntity, summonerEntity, participantByMatchId.get(match.getGameId())
                 ));
@@ -94,10 +112,12 @@ public class MatchHistoryService {
 
         if (newMatchPlayed) {
             matchRepository.saveAll(newMatches);
-            matchSummonerRepository.saveAll(newMatchSummoners);
+            matchSummonerRepository.saveAllAndFlush(newMatchSummoners);
+        } else if (newMatchSummoner) {
+            matchSummonerRepository.saveAllAndFlush(newMatchSummoners);
         }
 
-        if (newMatchPlayed && !isNewSummoner) {
+        if ((newMatchPlayed || newMatchSummoner) && !isNewSummoner) {
             List<MatchSummonerEntity> lastMatches = matchSummonerRepository.findLastMatchesBySummonerId(summonerEntity.getPuuid(), DB_FETCH_MATCHES);
 
             if (lastMatches.isEmpty()) {

--- a/src/main/java/com/kuroneko/service/MatchHistoryService.java
+++ b/src/main/java/com/kuroneko/service/MatchHistoryService.java
@@ -50,9 +50,8 @@ public class MatchHistoryService {
                 .withPuuid(summonerEntity.getPuuid())
                 .get()));
 
-        List<Long> longMatchIds = matchIds.stream().map(id -> Long.parseLong(id.split("_")[1])).toList();
-        Map<Long, MatchSummonerEntity> existingMatchIdsForSummoner =
-                matchSummonerRepository.findByMatchIdsAndSummonerPuuid(longMatchIds, summonerEntity.getPuuid())
+        Map<String, MatchSummonerEntity> existingMatchIdsForSummoner =
+                matchSummonerRepository.findByMatchIdsAndSummonerPuuid(matchIds, summonerEntity.getPuuid())
                         .stream()
                         .collect(Collectors.toMap(
                                 matchSummonerEntity -> matchSummonerEntity.getMatch().getMatchId(),
@@ -60,10 +59,10 @@ public class MatchHistoryService {
                         ));
 
         List<String> newMatchIds = matchIds.stream()
-                .filter(matchId -> !existingMatchIdsForSummoner.containsKey(Long.parseLong(matchId.split("_")[1])))
+                .filter(matchId -> !existingMatchIdsForSummoner.containsKey(matchId))
                 .toList();
 
-        Map<Long, MatchParticipant> participantByMatchId = new HashMap<>();
+        Map<String, MatchParticipant> participantByMatchId = new HashMap<>();
         List<LOLMatch> lolMatches = new ArrayList<>();
 
         for (String matchId : newMatchIds) {
@@ -81,15 +80,15 @@ public class MatchHistoryService {
 
             if (matchParticipant != null) {
                 lolMatches.add(match);
-                participantByMatchId.put(match.getGameId(), matchParticipant);
+                participantByMatchId.put(matchId, matchParticipant);
             }
         }
 
-        List<Long> gameIds = lolMatches.stream()
-                .map(LOLMatch::getGameId)
+        List<String> gameIds = lolMatches.stream()
+                .map(lolMatch -> lolMatch.getPlatform().getValue() + "_" + lolMatch.getGameId())
                 .toList();
 
-        Map<Long, MatchEntity> existingMatches = new HashMap<>(matchRepository.findAllById(gameIds)
+        Map<String, MatchEntity> existingMatches = new HashMap<>(matchRepository.findAllById(gameIds)
                 .stream()
                 .collect(Collectors.toMap(
                         MatchEntity::getMatchId,
@@ -97,20 +96,21 @@ public class MatchHistoryService {
                 )));
 
         for (LOLMatch match : lolMatches) {
-            if (!existingMatches.containsKey(match.getGameId())) {
+            String matchId = match.getPlatform().getValue() + "_" + match.getGameId();
+            if (!existingMatches.containsKey(matchId)) {
                 newMatchPlayed = true;
-                MatchEntity newMatchEntity = MatchMapper.map(match);
+                MatchEntity newMatchEntity = MatchMapper.map(match, matchId);
 
                 newMatches.add(newMatchEntity);
                 newMatchSummoners.add(MatchSummonerMapper.map(
-                        newMatchEntity, summonerEntity, participantByMatchId.get(match.getGameId())
+                        newMatchEntity, summonerEntity, participantByMatchId.get(matchId)
                 ));
-            } else if (!existingMatchIdsForSummoner.containsKey(match.getGameId())) {
+            } else if (!existingMatchIdsForSummoner.containsKey(matchId)) {
                 newMatchSummoner = true;
 
-                MatchEntity newMatchEntity = existingMatches.get(match.getGameId());
+                MatchEntity newMatchEntity = existingMatches.get(matchId);
                 newMatchSummoners.add(MatchSummonerMapper.map(
-                        newMatchEntity, summonerEntity, participantByMatchId.get(match.getGameId())
+                        newMatchEntity, summonerEntity, participantByMatchId.get(matchId)
                 ));
             }
         }

--- a/src/main/java/com/kuroneko/service/MatchHistoryService.java
+++ b/src/main/java/com/kuroneko/service/MatchHistoryService.java
@@ -44,16 +44,29 @@ public class MatchHistoryService {
         int fetchCount = isNewSummoner ? API_FETCH_MATCHES_NEW_SUMMONER : API_FETCH_MATCHES_CRON;
 
         List<String> matchIds = new ArrayList<>();
-        RELEVANT_QUEUES.forEach(queue -> matchIds.addAll(summoner.getLeagueGames()
+        RELEVANT_QUEUES_MATCH_HISTORY.forEach(queue -> matchIds.addAll(summoner.getLeagueGames()
                 .withCount(fetchCount)
                 .withQueue(queue)
                 .withPuuid(summonerEntity.getPuuid())
                 .get()));
 
+        List<Long> longMatchIds = matchIds.stream().map(id -> Long.parseLong(id.split("_")[1])).toList();
+        Map<Long, MatchSummonerEntity> existingMatchIdsForSummoner =
+                matchSummonerRepository.findByMatchIdsAndSummonerPuuid(longMatchIds, summonerEntity.getPuuid())
+                        .stream()
+                        .collect(Collectors.toMap(
+                                matchSummonerEntity -> matchSummonerEntity.getMatch().getMatchId(),
+                                matchSummonerEntity -> matchSummonerEntity
+                        ));
+
+        List<String> newMatchIds = matchIds.stream()
+                .filter(matchId -> !existingMatchIdsForSummoner.containsKey(Long.parseLong(matchId.split("_")[1])))
+                .toList();
+
         Map<Long, MatchParticipant> participantByMatchId = new HashMap<>();
         List<LOLMatch> lolMatches = new ArrayList<>();
 
-        for (String matchId : matchIds) {
+        for (String matchId : newMatchIds) {
             LOLMatch match = new MatchBuilder(summoner.getPlatform())
                     .withId(matchId)
                     .getMatch();
@@ -82,14 +95,6 @@ public class MatchHistoryService {
                         MatchEntity::getMatchId,
                         matchEntity -> matchEntity
                 )));
-
-        Map<Long, MatchSummonerEntity> existingMatchIdsForSummoner =
-                matchSummonerRepository.findByMatchIdsAndSummonerPuuid(gameIds, summonerEntity.getPuuid())
-                        .stream()
-                        .collect(Collectors.toMap(
-                                matchSummonerEntity -> matchSummonerEntity.getMatch().getMatchId(),
-                                matchSummonerEntity -> matchSummonerEntity
-                        ));
 
         for (LOLMatch match : lolMatches) {
             if (!existingMatches.containsKey(match.getGameId())) {
@@ -136,7 +141,7 @@ public class MatchHistoryService {
             );
 
             groupedByQueue.forEach((queue, matchSummonerList) -> {
-                if (!RELEVANT_QUEUES.contains(queue) || matchSummonerList.isEmpty()) {
+                if (!RELEVANT_QUEUES_MATCH_HISTORY.contains(queue) || matchSummonerList.isEmpty()) {
                     return;
                 }
 


### PR DESCRIPTION
spraw aby matchSummonerEntity był tworzony dla każdego summonera dla w bazie dla danego meczu, jeśli matchEntity już istniało w bazie.

Poprzednio matchSummonerEntity było tworzone tylko jeśli nie istaniło MatchEntity, więc towrzyliśmy tylko jedno MatchSummonerEntity i nigdy więcej

Teraz tworzymy matchSummonerEntity jeśli nie ma matchSummonerEntity dla danego summonera, nawet jeśli sam MatchEntity istnieje (wiele summonerów z db może grać w ten sam mecz)